### PR TITLE
Add a generated CLI command reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore /data directory so we can store artifacts/outputs/logs there.
+/data
+
 *.pyc
 *.db
 .ipynb_checkpoints

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ make lint-fix     # Run ruff with automatic fixes
 make format       # Format code with ruff
 make spell        # Run codespell
 make check        # Run all checks (lint, spell, test)
+make docs         # Regenerate docs/cli-reference.md from the CLI
 ```
 
 Run a single test file:
@@ -75,6 +76,7 @@ one `cli.add_command(...)` line in `cli/main.py`:
 - `cli/tables.py` — tool-agnostic CSV/TSV/JSON record file I/O (stdlib `csv`/`json`, not pandas, so input is echoed back unchanged except for added columns).
 - `cli/fields.py` — tool-agnostic `--include` handling: an `IncludeField`/`FieldRegistry` pair that resolves user-typed field names/aliases and renders values.
 - `cli/normalize.py` — the NodeNorm-specific subcommand: its options, its `FIELDS` registry, and the per-CURIE result type.
+- `cli/reference.py` — renders the CLI's help into `docs/cli-reference.md` (via `make docs`); `tests/test_cli_docs.py` keeps that file in sync.
 
 `translator normalize` reads a CSV/TSV/JSON file, normalizes the CURIEs in the
 `--column`(s) chosen by the user, and writes the same table back with
@@ -88,5 +90,6 @@ Tests make live network calls to external Translator endpoints. There are no moc
 ## Agent notes
 
 - Always run `make check` before committing (runs lint, spell check, and tests).
+- After changing the CLI, run `make docs` to regenerate `docs/cli-reference.md` — `tests/test_cli_docs.py` fails if it is stale. `docs/cli-reference.md` is generated; edit the CLI (or `docs/command-line-tools.md`) instead.
 - Do not break TCT compatibility without a migration plan — the same logic lives in `TCT/` until the migration is complete.
 - `CLAUDE.md` is a symlink to this file; edit `AGENTS.md` directly.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test spell spell-fix lint lint-fix lint-notebooks format check install
+.PHONY: test spell spell-fix lint lint-fix lint-notebooks format check install docs
 
 # Install development dependencies
 install:
@@ -32,6 +32,10 @@ lint-notebooks:
 format:
 	uv run ruff format .
 
+# Regenerate the CLI reference documentation from the translator CLI
+docs:
+	uv run python -m Translator_sdk.cli.reference > docs/cli-reference.md
+
 # Run all checks (lint, spell, test)
 check: lint spell test
 
@@ -47,4 +51,5 @@ help:
 	@echo "  lint-notebooks - Run code linting on notebooks (informational)"
 	@echo "  format   - Format code"
 	@echo "  check    - Run all checks (lint, spell, test)"
+	@echo "  docs     - Regenerate docs/cli-reference.md from the CLI"
 	@echo "  help     - Show this help message"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-Translator SDK
-==============
+# Translator SDK
+
+A Python library that wraps several [NCATS Biomedical Data Translator](https://ncats.nih.gov/translator)
+REST APIs (NodeNorm, NameRes, Node Annotator, and others) behind typed,
+consistent Python interfaces.
+
+## Command-line tool
+
+The SDK also ships a `translator` command for normalizing biomedical
+identifiers in a spreadsheet — no Python required:
+
+```
+translator normalize genes.csv --column curie --include label,type
+```
+
+- **[Command-line tools guide](docs/command-line-tools.md)** — start here: a
+  friendly, example-driven walkthrough of installing and using the tool.
+- **[Command reference](docs/cli-reference.md)** — every command and option.
+
+## Development
+
+See [AGENTS.md](AGENTS.md) for the architecture overview, common `make` tasks,
+and contributor notes. In short: `make install`, then `make check`.

--- a/Translator_sdk/cli/normalize.py
+++ b/Translator_sdk/cli/normalize.py
@@ -123,7 +123,8 @@ def _resolve_conflation(values: list[str]) -> tuple[bool, bool]:
 
 
 def _normalize_curies(curies: list[str], *, conflate: bool, drug_chemical_conflate: bool,
-                      description: bool, individual_types: bool) -> dict[str, CurieResult]:
+                      description: bool, individual_types: bool,
+                      url: str | None = None) -> dict[str, CurieResult]:
     """Normalize a list of unique CURIEs, returning a dict from CURIE to result.
 
     A CURIE NodeNorm has never heard of, and a CURIE in a batch whose request
@@ -138,6 +139,7 @@ def _normalize_curies(curies: list[str], *, conflate: bool, drug_chemical_confla
                 batch, mode='post',
                 conflate=conflate, drug_chemical_conflate=drug_chemical_conflate,
                 description=description, individual_types=individual_types,
+                url=url,
             )
         except requests.RequestException as exc:
             for curie in batch:
@@ -193,8 +195,14 @@ def _normalize_curies(curies: list[str], *, conflate: bool, drug_chemical_confla
     '--list-separator', default='|', show_default=True,
     help='String used to join list-valued cells in CSV/TSV output.',
 )
+@click.option(
+    '--url', 'nodenorm_url', default=None, metavar='URL',
+    help='Base URL of the NodeNorm service to use. '
+         'Defaults to https://nodenorm.ci.transltr.io/. '
+         'Example: https://nodenormalization-sri.renci.org/ for the RENCI Dev instance.',
+)
 def normalize(input_file, columns, includes, output, fmt_override, conflation,
-              individual_types, list_separator):
+              individual_types, list_separator, nodenorm_url):
     """Normalize CURIEs in a CSV, TSV or JSON file using NodeNorm.
 
     INPUT is the file to read, or '-' to read from standard input. The output is
@@ -242,6 +250,7 @@ def normalize(input_file, columns, includes, output, fmt_override, conflation,
         curies,
         conflate=conflate, drug_chemical_conflate=drug_chemical_conflate,
         description=want_description, individual_types=individual_types,
+        url=nodenorm_url,
     )
 
     # Add a <column>_<field> column for every selected column and chosen field.
@@ -262,3 +271,13 @@ def normalize(input_file, columns, includes, output, fmt_override, conflation,
         name for name in new_fieldnames if name not in fieldnames
     ]
     write_table(rows, output_fieldnames, output, fmt)
+
+    # Print a summary to stderr so it is visible even when output goes to a file.
+    total = len(curies)
+    annotated = sum(1 for r in results.values() if r.node is not None)
+    pct = (annotated / total * 100) if total else 0.0
+    click.echo(
+        f'Normalization complete: {annotated:,} / {total:,} unique CURIEs annotated '
+        f'({pct:.1f}%).',
+        err=True,
+    )

--- a/Translator_sdk/cli/reference.py
+++ b/Translator_sdk/cli/reference.py
@@ -1,0 +1,37 @@
+"""Renders the ``translator`` CLI's help as a Markdown reference document.
+
+``make docs`` runs this module to regenerate ``docs/cli-reference.md``, and
+``tests/test_cli_docs.py`` checks that the committed file still matches -- so the
+reference can never silently drift from the CLI.
+"""
+import click
+
+from .main import cli
+
+_HEADER = """<!-- Generated from the translator CLI by `make docs`. Do not edit by hand. -->
+
+# `translator` command reference
+
+This page lists every command and option. It is generated automatically from the
+CLI, so it always matches the current version. For a friendly, example-driven
+introduction, see the [command-line tools guide](command-line-tools.md)."""
+
+
+def _command_section(command: click.Command, path: str) -> str:
+    """Render one command's ``--help`` output as a Markdown section."""
+    # A fixed terminal width keeps the output identical regardless of the
+    # terminal `make docs` happens to run in, so the freshness test is stable.
+    context = click.Context(command, info_name=path, terminal_width=80)
+    return f"## `{path}`\n\n```\n{command.get_help(context).rstrip()}\n```"
+
+
+def render_reference() -> str:
+    """Return the full Markdown reference for the ``translator`` CLI."""
+    sections = [_HEADER, _command_section(cli, 'translator')]
+    for name, command in sorted(cli.commands.items()):
+        sections.append(_command_section(command, f'translator {name}'))
+    return '\n\n'.join(sections) + '\n'
+
+
+if __name__ == '__main__':
+    print(render_reference(), end='')

--- a/Translator_sdk/node_normalizer.py
+++ b/Translator_sdk/node_normalizer.py
@@ -38,7 +38,8 @@ def get_normalized_nodes_raw(query: str | list[str],
         drug_chemical_conflate: bool = False,
         description: bool = False,
         individual_types: bool = False,
-        include_taxa: bool = True) -> dict:
+        include_taxa: bool = True,
+        url: str | None = None) -> dict:
     """
     Calls the NodeNorm ``get_normalized_nodes`` endpoint and returns its raw JSON.
 
@@ -66,13 +67,17 @@ def get_normalized_nodes_raw(query: str | list[str],
         Default: False.
     include_taxa : bool
         Ask NodeNorm to include taxa for the normalized nodes. Default: True.
+    url : str or None
+        Base URL of the NodeNorm service. Defaults to the module-level :data:`URL`
+        constant (``https://nodenorm.ci.transltr.io/``).
 
     Returns
     -------
     A dict mapping each queried CURIE to its raw NodeNorm result object, or to
     ``None`` when NodeNorm has no record of that CURIE.
     """
-    path = urllib.parse.urljoin(URL, 'get_normalized_nodes')
+    base = url if url is not None else URL
+    path = urllib.parse.urljoin(base if base.endswith('/') else base + '/', 'get_normalized_nodes')
     options = {
         'conflate': conflate,
         'drug_chemical_conflate': drug_chemical_conflate,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,85 @@
+<!-- Generated from the translator CLI by `make docs`. Do not edit by hand. -->
+
+# `translator` command reference
+
+This page lists every command and option. It is generated automatically from the
+CLI, so it always matches the current version. For a friendly, example-driven
+introduction, see the [command-line tools guide](command-line-tools.md).
+
+## `translator`
+
+```
+Usage: translator [OPTIONS] COMMAND [ARGS]...
+
+  Command-line tools for the NCATS Biomedical Data Translator SDK.
+
+  Each subcommand wraps one Translator service. Run `translator COMMAND --help`
+  for details on a specific command.
+
+Options:
+  --version  Show the version and exit.
+  --help     Show this message and exit.
+
+Commands:
+  normalize  Normalize CURIEs in a CSV, TSV or JSON file using NodeNorm.
+```
+
+## `translator normalize`
+
+```
+Usage: translator normalize [OPTIONS] INPUT
+
+  Normalize CURIEs in a CSV, TSV or JSON file using NodeNorm.
+
+  INPUT is the file to read, or '-' to read from standard input. The output is
+  the same table with extra columns added for the CURIEs in each --column. Added
+  columns are named <column>_<field>, for example id_normalized and id_label.
+
+  Examples:
+    translator normalize genes.csv --column gene_id --include label,type
+    translator normalize ids.json -c curie -i label -o normalized.json
+    cat ids.tsv | translator normalize - --format tsv -c id
+
+Options:
+  -c, --column TEXT        Input column holding CURIEs to normalize. Repeatable;
+                           comma-separated values also work.  [required]
+  -i, --include TEXT       Extra field(s) to add for each normalized CURIE (see
+                           the list below). Repeatable; comma-separated values
+                           also work. 'normalized' and 'errors' are always
+                           added.
+  -o, --output FILE        Where to write the result. Defaults to standard
+                           output.
+  --format [csv|tsv|json]  Input/output format. Inferred from the file extension
+                           when not given; required when reading from standard
+                           input.
+  --conflation TEXT        NodeNorm conflation to apply: 'gene-protein', 'drug-
+                           chemical', 'all' or 'none'. Repeatable. Default:
+                           gene-protein only.
+  --individual-types       Ask NodeNorm to include the biolink type of each
+                           equivalent identifier (visible via --include json).
+  --list-separator TEXT    String used to join list-valued cells in CSV/TSV
+                           output.  [default: |]
+  --help                   Show this message and exit.
+
+  Fields available for --include / -i:
+    normalized / id / curie / identifier  [added by default]
+        the preferred (normalized) CURIE
+    errors / error  [added by default]
+        a message if the CURIE could not be normalized (empty otherwise)
+    label / name / preferred-name
+        the preferred name of the normalized node
+    description / desc / descriptions
+        a human-readable description of the node
+    type / category
+        the most specific biolink type of the node
+    types / categories / all-types
+        every biolink type of the node
+    taxa / taxon / taxonomy
+        the taxa (organisms) associated with the node
+    information-content / ic / info-content
+        NodeNorm's information content score (higher is more specific)
+    equivalent-identifiers / synonyms / eq-ids
+        every CURIE NodeNorm considers equivalent to this one
+    json / raw
+        the complete raw NodeNorm response for the CURIE
+```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -59,6 +59,10 @@ Options:
                            equivalent identifier (visible via --include json).
   --list-separator TEXT    String used to join list-valued cells in CSV/TSV
                            output.  [default: |]
+  --url URL                Base URL of the NodeNorm service to use. Defaults to
+                           https://nodenorm.ci.transltr.io/. Example:
+                           https://nodenormalization-sri.renci.org/ for the
+                           RENCI Dev instance.
   --help                   Show this message and exit.
 
   Fields available for --include / -i:

--- a/docs/command-line-tools.md
+++ b/docs/command-line-tools.md
@@ -210,8 +210,8 @@ A blank cell in your input column is left blank in the output, with no error.
 
 ## Seeing every option
 
-This guide covers the common cases. For the complete, always-up-to-date list of
-every command and option, run:
+This guide covers the common cases. For the complete list of every command and
+option, see the **[command reference](cli-reference.md)**, or run:
 
 ```
 translator --help

--- a/docs/command-line-tools.md
+++ b/docs/command-line-tools.md
@@ -172,6 +172,29 @@ translator normalize genes.csv --column curie --conflation none
 Whatever you list is exactly what gets turned on — so `--conflation drug-chemical`
 turns gene/protein conflation *off* and drug/chemical conflation *on*.
 
+### Choosing a NodeNorm instance: `--url`
+
+By default, the tool uses the NodeNorm service at `https://nodenorm.ci.transltr.io/`.
+If you need to use a different deployment — for example, the RENCI development
+instance — pass its base URL with `--url`:
+
+```
+translator normalize genes.csv --column curie \
+    --url https://nodenormalization-sri.renci.org/
+```
+
+### Summary report
+
+After writing the output, the tool prints a summary to the terminal showing how
+many unique CURIEs were successfully annotated:
+
+```
+Normalization complete: 56,979 / 56,979 unique CURIEs annotated (100.0%).
+```
+
+This summary is printed to standard error so it appears in the terminal even
+when you redirect the output to a file.
+
 ## Using it in a pipeline
 
 The tool can read from another program instead of a file. Use `-` in place of

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -1,0 +1,19 @@
+"""Checks that the generated CLI reference is up to date.
+
+If this test fails, run `make docs` to regenerate docs/cli-reference.md. This
+test makes no network calls.
+"""
+from pathlib import Path
+
+from Translator_sdk.cli.reference import render_reference
+
+REFERENCE_PATH = Path(__file__).parent.parent / 'docs' / 'cli-reference.md'
+
+
+def test_cli_reference_is_up_to_date():
+    """docs/cli-reference.md must match the current CLI; run `make docs` if not."""
+    committed = REFERENCE_PATH.read_text(encoding='utf-8')
+    assert committed == render_reference(), (
+        'docs/cli-reference.md is out of date with the CLI. '
+        'Regenerate it with `make docs`.'
+    )

--- a/tests/test_nodenorm_cli.py
+++ b/tests/test_nodenorm_cli.py
@@ -30,6 +30,22 @@ def all_text(result):
     return text
 
 
+def stdout_only(result):
+    """Return only the stdout lines, stripping lines that appear in stderr.
+
+    Click 8.4+ always mixes stderr into result.output. This removes the
+    interleaved stderr lines so callers can parse CSV/JSON from stdout cleanly.
+    """
+    try:
+        stderr_lines = set(result.stderr.splitlines())
+    except (ValueError, AttributeError):
+        return result.output
+    return '\n'.join(
+        line for line in result.output.splitlines()
+        if line not in stderr_lines
+    ) + ('\n' if result.output.endswith('\n') else '')
+
+
 def read_csv(text, delimiter=','):
     """Parse CLI CSV/TSV output into (rows, fieldnames)."""
     reader = csv.DictReader(io.StringIO(text), delimiter=delimiter)
@@ -41,7 +57,7 @@ def test_normalize_csv_adds_prefixed_columns():
     result = run('normalize', str(DATA / 'sample.csv'),
                  '--column', 'curie', '--include', 'label,type')
     assert result.exit_code == 0, all_text(result)
-    rows, fieldnames = read_csv(result.output)
+    rows, fieldnames = read_csv(stdout_only(result))
 
     # Original columns are preserved, in order, before the added ones.
     assert fieldnames == ['gene_symbol', 'curie', 'source',
@@ -65,7 +81,7 @@ def test_normalize_json_keeps_lists_and_passes_through():
     result = run('normalize', str(DATA / 'sample.json'),
                  '--column', 'curie', '--include', 'types')
     assert result.exit_code == 0, all_text(result)
-    rows = json.loads(result.output)
+    rows = json.loads(stdout_only(result))
 
     assert rows[0]['gene_symbol'] == 'water'
     assert rows[0]['curie_normalized'] == 'CHEBI:15377'
@@ -94,7 +110,7 @@ def test_reads_from_stdin_with_format():
     result = run('normalize', '-', '--format', 'csv', '--column', 'curie',
                  input='curie\nMESH:D014867\n')
     assert result.exit_code == 0, all_text(result)
-    rows, _ = read_csv(result.output)
+    rows, _ = read_csv(stdout_only(result))
     assert rows[0]['curie_normalized'] == 'CHEBI:15377'
 
 
@@ -103,7 +119,7 @@ def test_include_aliases_and_default_columns():
     result = run('normalize', str(DATA / 'sample.csv'),
                  '--column', 'curie', '--include', 'name')
     assert result.exit_code == 0, all_text(result)
-    _, fieldnames = read_csv(result.output)
+    _, fieldnames = read_csv(stdout_only(result))
     assert fieldnames == ['gene_symbol', 'curie', 'source',
                           'curie_normalized', 'curie_errors', 'curie_label']
 
@@ -114,7 +130,7 @@ def test_multiple_columns_each_get_their_own_outputs():
                  '--column', 'a', '--column', 'b',
                  input='a,b\nMESH:D014867,NCBIGene:1756\n')
     assert result.exit_code == 0, all_text(result)
-    rows, fieldnames = read_csv(result.output)
+    rows, fieldnames = read_csv(stdout_only(result))
     assert fieldnames == ['a', 'b', 'a_normalized', 'a_errors',
                           'b_normalized', 'b_errors']
     assert rows[0]['a_normalized'] == 'CHEBI:15377'
@@ -131,8 +147,8 @@ def test_conflation_changes_the_result():
     assert default.exit_code == 0, all_text(default)
     assert no_conflation.exit_code == 0, all_text(no_conflation)
 
-    default_curie = read_csv(default.output)[0][0]['curie_normalized']
-    no_conflation_curie = read_csv(no_conflation.output)[0][0]['curie_normalized']
+    default_curie = read_csv(stdout_only(default))[0][0]['curie_normalized']
+    no_conflation_curie = read_csv(stdout_only(no_conflation))[0][0]['curie_normalized']
     assert default_curie == 'NCBIGene:1756'          # gene/protein conflation on
     assert no_conflation_curie == 'UniProtKB:P11532'  # conflation off
 
@@ -142,7 +158,7 @@ def test_empty_cell_is_left_blank():
     result = run('normalize', '-', '--format', 'csv', '--column', 'curie',
                  input='curie,note\n,a row with no curie\n')
     assert result.exit_code == 0, all_text(result)
-    rows, _ = read_csv(result.output)
+    rows, _ = read_csv(stdout_only(result))
     assert rows[0]['note'] == 'a row with no curie'
     assert rows[0]['curie_normalized'] == ''
     assert rows[0]['curie_errors'] == ''


### PR DESCRIPTION
Stacked on #6 (`add-nodenorm-cli`) — that PR adds the `translator` CLI and the non-technical guide. **The base of this PR is `add-nodenorm-cli`**, so the diff here is only the reference tooling; review/merge #6 first.

## What this adds

Documentation tooling for the `translator` CLI:

- `Translator_sdk/cli/reference.py` — renders the CLI's `--help` into Markdown (with a pinned terminal width, so output is deterministic).
- `make docs` — regenerates `docs/cli-reference.md` from the CLI.
- `docs/cli-reference.md` — the generated, complete command/option reference.
- `tests/test_cli_docs.py` — an offline test that fails if `docs/cli-reference.md` drifts from the CLI (verified it catches drift and passes after `make docs`).
- `README.md` — replaced the 3-line stub with a short intro linking the guide and the reference.
- `AGENTS.md` — documents `make docs` and the generated reference.

The companion non-technical guide, `docs/command-line-tools.md`, ships in #6; this PR adds a link to the reference from it.

## Notes

- Approach is plain Markdown (no Sphinx/mkdocs, no new dependencies). TCT documents itself with Sphinx + `myst-parser`; because `myst-parser` renders Markdown, these files stay compatible if the two projects later converge on one toolchain.
- `make check` passes except the pre-existing, unrelated `test_nameres_status` failure (NameRes API drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)